### PR TITLE
Enable CPU and Memory accounting for systemd services by default when…

### DIFF
--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -18,6 +18,7 @@
   tags:
     - etcd
 
+# Install docker
 - hosts: all
   sudo: yes
   roles:

--- a/ansible/roles/common/files/kubernetes-accounting.conf
+++ b/ansible/roles/common/files/kubernetes-accounting.conf
@@ -1,0 +1,3 @@
+[Manager]
+DefaultCPUAccounting=yes
+DefaultMemoryAccounting=yes

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -80,3 +80,14 @@
 
 - include: fedora-install.yml
   when: not is_atomic and ansible_distribution == "Fedora"
+
+# enable cpu and memory accounting for systemd services by default
+- name: Create systemd dropin directory
+  file: path=/etc/systemd/system/system.conf.d state=directory mode=0755
+  when: source_type == "localBuild"
+
+- name: Enable cpu and memory accounting for systemd services
+  copy: src=kubernetes-accounting.conf dest="/etc/systemd/system/system.conf.d/kubernetes-accounting.conf"
+  when: source_type == "localBuild"
+  notify:
+    - reload systemd


### PR DESCRIPTION
… building from local sources.

For distribution packages (rpms, deb, etc.) let the installation mechanism to take care of accounting.

Quoting:
Fix system container detection in kubelet on systemd.

This fixed environments where CPU and Memory Accounting were not enabled on the unit
that launched the kubelet or docker from reporting the root cgroup when
monitoring usage stats for those components.

From: https://github.com/kubernetes/kubernetes/pull/25982
